### PR TITLE
Add status functions to dkg, vss and commitment

### DIFF
--- a/src/dkg_commitment.erl
+++ b/src/dkg_commitment.erl
@@ -11,6 +11,8 @@
          add_ready/3,
          num_echoes/1,
          num_readies/1,
+         echoes/1,
+         readies/1,
          matrix/1,
          set_matrix/2,
          serialize/1,
@@ -114,6 +116,14 @@ num_echoes(#commitment{echoes=Echoes}) ->
 -spec num_readies(commitment()) -> non_neg_integer().
 num_readies(#commitment{readies=Readies}) ->
     maps:size(Readies).
+
+-spec echoes(commitment()) -> #{pos_integer() => erlang_pbc:element()}.
+echoes(#commitment{echoes=Echoes}) ->
+    Echoes.
+
+-spec readies(commitment()) -> #{pos_integer() => erlang_pbc:element()}.
+readies(#commitment{readies=Readies}) ->
+    Readies.
 
 -spec matrix(commitment()) -> dkg_commitmentmatrix:matrix().
 matrix(#commitment{matrix=Matrix}) ->

--- a/src/dkg_commitment.erl
+++ b/src/dkg_commitment.erl
@@ -14,8 +14,7 @@
          matrix/1,
          set_matrix/2,
          serialize/1,
-         deserialize/2,
-         status/1
+         deserialize/2
         ]).
 
 -record(commitment, {

--- a/src/dkg_commitment.erl
+++ b/src/dkg_commitment.erl
@@ -14,7 +14,8 @@
          matrix/1,
          set_matrix/2,
          serialize/1,
-         deserialize/2
+         deserialize/2,
+         status/1
         ]).
 
 -record(commitment, {

--- a/src/dkg_hybriddkg.erl
+++ b/src/dkg_hybriddkg.erl
@@ -523,7 +523,9 @@ status(DKG) ->
       vss_map => maps:map(fun(_K, VSS) -> dkg_hybridvss:status(VSS) end, DKG#dkg.vss_map),
       vss_results_from => maps:keys(DKG#dkg.vss_results),
       echoes_from => maps:keys(DKG#dkg.elq),
+      echoes_received => maps:map(fun(_K, V) -> length(maps:values(V)) end, DKG#dkg.elq),
       readies_from => maps:keys(DKG#dkg.rlq),
+      readies_received => maps:map(fun(_K, V) -> length(maps:values(V)) end, DKG#dkg.rlq),
       lc_flag => DKG#dkg.lc_flag,
       leader => DKG#dkg.leader,
       l_next => DKG#dkg.l_next}.

--- a/src/dkg_hybriddkg.erl
+++ b/src/dkg_hybriddkg.erl
@@ -522,13 +522,8 @@ status(DKG) ->
     #{id => DKG#dkg.id,
       vss_map => maps:map(fun(_K, VSS) -> dkg_hybridvss:status(VSS) end, DKG#dkg.vss_map),
       vss_results => maps:map(fun(_K, {C, Si}) -> {dkg_commitment:status(C), erlang_pbc:element_to_binary(Si)} end, DKG#dkg.vss_results),
-      qbar => DKG#dkg.qbar,
-      qhat => DKG#dkg.qhat,
-      rhat => DKG#dkg.rhat,
-      mbar => DKG#dkg.mbar,
-      elq => DKG#dkg.elq,
-      rlq => DKG#dkg.rlq,
+      echoes_from => maps:keys(DKG#dkg.elq),
+      readies_from => maps:keys(DKG#dkg.rlq),
       lc_flag => DKG#dkg.lc_flag,
       leader => DKG#dkg.leader,
-      l_next => DKG#dkg.l_next,
-      lc_map => DKG#dkg.lc_map}.
+      l_next => DKG#dkg.l_next}.

--- a/src/dkg_hybriddkg.erl
+++ b/src/dkg_hybriddkg.erl
@@ -521,7 +521,7 @@ deserialize_vss_results(SerializedVSSResults, U) ->
 status(DKG) ->
     #{id => DKG#dkg.id,
       vss_map => maps:map(fun(_K, VSS) -> dkg_hybridvss:status(VSS) end, DKG#dkg.vss_map),
-      vss_results => maps:map(fun(_K, {C, Si}) -> {dkg_commitment:status(C), erlang_pbc:element_to_binary(Si)} end, DKG#dkg.vss_results),
+      vss_results_from => maps:keys(DKG#dkg.vss_results),
       echoes_from => maps:keys(DKG#dkg.elq),
       readies_from => maps:keys(DKG#dkg.rlq),
       lc_flag => DKG#dkg.lc_flag,

--- a/src/dkg_hybriddkg.erl
+++ b/src/dkg_hybriddkg.erl
@@ -3,7 +3,8 @@
 -export([init/7,
          start/1,
          serialize/1,
-         deserialize/2
+         deserialize/2,
+         status/1
         ]).
 
 -export([handle_msg/3]).
@@ -515,3 +516,19 @@ deserialize_vss_results(SerializedVSSResults, U) ->
     maps:fold(fun(K, {C, Si}, Acc) ->
                       maps:put(K, {dkg_commitment:deserialize(C, U), erlang_pbc:binary_to_element(U, Si)}, Acc)
               end, #{}, SerializedVSSResults).
+
+-spec status(dkg()) -> map().
+status(DKG) ->
+    #{id => DKG#dkg.id,
+      vss_map => maps:map(fun(_K, VSS) -> dkg_hybridvss:status(VSS) end, DKG#dkg.vss_map),
+      vss_results => maps:map(fun(_K, {C, Si}) -> {dkg_commitment:status(C), erlang_pbc:element_to_binary(Si)} end, DKG#dkg.vss_results),
+      qbar => DKG#dkg.qbar,
+      qhat => DKG#dkg.qhat,
+      rhat => DKG#dkg.rhat,
+      mbar => DKG#dkg.mbar,
+      elq => DKG#dkg.elq,
+      rlq => DKG#dkg.rlq,
+      lc_flag => DKG#dkg.lc_flag,
+      leader => DKG#dkg.leader,
+      l_next => DKG#dkg.l_next,
+      lc_map => DKG#dkg.lc_map}.

--- a/src/dkg_hybridvss.erl
+++ b/src/dkg_hybridvss.erl
@@ -5,7 +5,8 @@
 -export([input/2,
          commitment/1,
          serialize/1,
-         deserialize/2
+         deserialize/2,
+         status/1
         ]).
 
 -export([handle_msg/3]).
@@ -257,3 +258,14 @@ deserialize(#serialized_vss{id=Id,
          received_commitment=ReceivedCommitment,
          readies=Readies,
          commitment=dkg_commitment:deserialize(SerializedCommitment, Element)}.
+
+-spec status(vss()) -> map().
+status(VSS) ->
+    #{id => VSS#vss.id,
+      session => VSS#vss.session,
+      sent_echo => VSS#vss.sent_echo,
+      received_commitment => VSS#vss.received_commitment,
+      echoes => VSS#vss.echoes,
+      readies => VSS#vss.readies,
+      commitment => dkg_commitment:status(VSS#vss.commitment)
+     }.

--- a/src/dkg_hybridvss.erl
+++ b/src/dkg_hybridvss.erl
@@ -265,7 +265,6 @@ status(VSS) ->
       session => VSS#vss.session,
       sent_echo => VSS#vss.sent_echo,
       received_commitment => VSS#vss.received_commitment,
-      echoes => VSS#vss.echoes,
-      readies => VSS#vss.readies,
-      commitment => dkg_commitment:status(VSS#vss.commitment)
+      echoes_from => maps:keys(VSS#vss.echoes),
+      readies_from => maps:keys(VSS#vss.readies)
      }.


### PR DESCRIPTION
Let me know if a K:V pair isn't explicitly needed in any of the statuses.

Note: CommitmentMatrix is just a three tuple (hence not adding a status for it).