### PR TITLE
Serialize commitments properly

### DIFF
--- a/src/dkg_commitment.erl
+++ b/src/dkg_commitment.erl
@@ -21,16 +21,16 @@
           matrix :: dkg_commitmentmatrix:matrix(),
           generator :: erlang_pbc:element(),
           nodes = [] :: [pos_integer()],
-          echoes = #{} :: map(),
-          readies =#{} :: map()
+          echoes = #{} :: #{pos_integer() => erlang_pbc:element()},
+          readies =#{} :: #{pos_integer() => erlang_pbc:element()}
          }).
 
 -record(serialized_commitment, {
           matrix :: dkg_commitmentmatrix:serialized_matrix(),
           generator :: binary(),
           nodes = [] :: [pos_integer()],
-          echoes = #{} :: map(),
-          readies = #{} :: map()
+          echoes = #{} :: #{pos_integer() => binary()},
+          readies = #{} :: #{pos_integer() => binary()}
          }).
 
 -type commitment() :: #commitment{}.
@@ -132,8 +132,8 @@ serialize(#commitment{matrix=Matrix,
     #serialized_commitment{matrix=dkg_commitmentmatrix:serialize(Matrix),
                            generator=erlang_pbc:element_to_binary(Generator),
                            nodes=Nodes,
-                           echoes=Echoes,
-                           readies=Readies}.
+                           echoes=maps:map(fun(_K, V) -> erlang_pbc:element_to_binary(V) end, Echoes),
+                           readies=maps:map(fun(_K, V) -> erlang_pbc:element_to_binary(V) end, Readies)}.
 
 -spec deserialize(serialized_commitment(), erlang_pbc:element()) -> commitment().
 deserialize(#serialized_commitment{matrix=SerializedMatrix,
@@ -144,5 +144,5 @@ deserialize(#serialized_commitment{matrix=SerializedMatrix,
     #commitment{matrix=dkg_commitmentmatrix:deserialize(SerializedMatrix, U),
                 generator=erlang_pbc:binary_to_element(U, SerializedGenerator),
                 nodes=Nodes,
-                echoes=Echoes,
-                readies=Readies}.
+                echoes=maps:map(fun(_K, V) -> erlang_pbc:binary_to_element(U, V) end, Echoes),
+                readies=maps:map(fun(_K, V) -> erlang_pbc:binary_to_element(U, V) end, Readies)}.

--- a/src/dkg_hybriddkg.erl
+++ b/src/dkg_hybriddkg.erl
@@ -37,7 +37,7 @@
           u :: binary(),
           u2 :: binary(),
           vss_map :: #{pos_integer() => dkg_hybridvss:serialized_vss()},
-          vss_results = #{} :: #{pos_integer() => {C :: dkg_commitment:serialized_commitment(), Si :: binary()}},
+          vss_results = #{} :: serialized_vss_results(),
           qbar = [] :: qset(),
           qhat = [] :: qset(),
           rhat = [] :: rhat(),


### PR DESCRIPTION
Note that the test doesn't actually fail if you remove the actual changes to the (de)serialization functions. I suspect this is caused by the garbage collector not running.