### PR TITLE
rename variables in hybrid dkg core code.

### DIFF
--- a/src/dkg_hybriddkg.erl
+++ b/src/dkg_hybriddkg.erl
@@ -119,7 +119,7 @@ start(DKG = #dkg{id=Id, u=G1}) ->
     {DKG#dkg{shares_map = SharesMap#{Id => NewShares}},
      {send, dkg_util:wrap({vss, Id}, ToSend)}}.
 
-handle_msg(DKG=#dkg{leader = Leader}, Sender, {{shares, SharesId}, SharesMsg}) ->
+handle_msg(DKG=#dkg{leader = Leader}, Sender, {{vss, SharesId}, SharesMsg}) ->
     case dkg_hybridvss:handle_msg(maps:get(SharesId, DKG#dkg.shares_map), Sender, SharesMsg) of
         {_Shares, ignore} ->
             {DKG, ignore};

--- a/src/dkg_hybriddkg.erl
+++ b/src/dkg_hybriddkg.erl
@@ -117,7 +117,7 @@ start(DKG = #dkg{id=Id, u=G1}) ->
     Secret = erlang_pbc:element_random(erlang_pbc:element_new('Zr', G1)),
     {NewShares, {send, ToSend}} = dkg_hybridvss:input(MyShares, Secret),
     {DKG#dkg{shares_map = SharesMap#{Id => NewShares}},
-     {send, dkg_util:wrap({shares, Id}, ToSend)}}.
+     {send, dkg_util:wrap({vss, Id}, ToSend)}}.
 
 handle_msg(DKG=#dkg{leader = Leader}, Sender, {{shares, SharesId}, SharesMsg}) ->
     case dkg_hybridvss:handle_msg(maps:get(SharesId, DKG#dkg.shares_map), Sender, SharesMsg) of
@@ -126,7 +126,7 @@ handle_msg(DKG=#dkg{leader = Leader}, Sender, {{shares, SharesId}, SharesMsg}) -
         {NewShares, ok} ->
             {DKG#dkg{shares_map=maps:put(SharesId, NewShares, DKG#dkg.shares_map)}, ok};
         {NewShares, {send, ToSend}} ->
-            {DKG#dkg{shares_map=maps:put(SharesId, NewShares, DKG#dkg.shares_map)}, {send, dkg_util:wrap({shares, SharesId}, ToSend)}};
+            {DKG#dkg{shares_map=maps:put(SharesId, NewShares, DKG#dkg.shares_map)}, {send, dkg_util:wrap({vss, SharesId}, ToSend)}};
         {NewShares, {result, {_Session, Commitment, Si}}} ->
             %% upon (Pd, τ, out, shared, Cd , si,d , Rd ) (first time):
             %%      Qhat ← {Pd}; Rhat ← {Rd}

--- a/test/dkg_relcast_worker.erl
+++ b/test/dkg_relcast_worker.erl
@@ -39,7 +39,7 @@ init(Args) ->
     ID = proplists:get_value(id, Args),
     DataDir = proplists:get_value(data_dir, Args),
     Members = lists:seq(1, N),
-    {ok, Relcast} = relcast:start(ID, Members, dkg_handler, [Args], [{data_dir, DataDir ++ integer_to_list(ID)}]),
+    {ok, Relcast} = relcast:start(ID, Members, dkg_handler, Args, [{data_dir, DataDir ++ integer_to_list(ID)}]),
     Peers = maps:from_list([{I, undefined} || I <- Members, I /= ID ]),
     {ok, do_send(#state{relcast=Relcast, id=ID, peers=Peers})}.
 


### PR DESCRIPTION
rename a lot of the variables to read more sensibly, provide a glossary that maps the terms to one another.