### PR TITLE
Ensure the VSS ready messages are signed

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 %% -*- erlang -*-
-{erl_opts, [debug_info, warn_untyped_record, warnings_as_errors]}.
+{erl_opts, [debug_info, warn_untyped_record]}. %%, warnings_as_errors]}.
 
 {ct_opts, [{sys_config, "test/test.config"}, {update_logger, true}]}.
 

--- a/src/dkg_hybriddkg.erl
+++ b/src/dkg_hybriddkg.erl
@@ -58,7 +58,7 @@
 
 -type node_set() :: [pos_integer()].
 -type echo_proofs() :: [signed_ready() | signed_echo()].
--type signed_leader_change() :: {signed_leader_change, pos_integer(), node_set(), vss_ready_proofs() | echo_proofs()}.
+-type signed_leader_change() :: {signed_leader_change, pos_integer(), vss_ready_proofs()} | {signed_leader_change, pos_integer(), node_set(), echo_proofs()}.
 -type signed_echo() :: {signed_echo, node_set()}.
 -type signed_ready() :: {signed_ready, node_set()}.
 -type vss_ready_proofs() :: [{VSSId :: pos_integer(), dkg_commitment:ready_proofs()}].
@@ -109,8 +109,8 @@ init(Id, N, F, T, G1, G2, Round, Options) ->
     %% occur so it's not safe to enable this in a non development context.
     Elections = proplists:get_value(elections, Options, false),
     %% these will cause an exception if not present in the options list
-    {signfun, SignFun} = lists:keyfind(signfun, 1, Options ++ [{signfun, fun(_) -> <<"lol">> end}]),
-    {verifyfun, VerifyFun} = lists:keyfind(verifyfun, 1, Options ++ [{verifyfun, fun(_, _, _) -> true end}]),
+    {signfun, SignFun} = lists:keyfind(signfun, 1, Options),
+    {verifyfun, VerifyFun} = lists:keyfind(verifyfun, 1, Options),
     Shares = lists:foldl(fun(E, Map) ->
                                  Share = dkg_hybridvss:init(Id, N, F, T, G1, G2, {E, Round}, Callback, SignFun, VerifyFun),
                                  Map#{E => Share}

--- a/src/dkg_hybriddkg.erl
+++ b/src/dkg_hybriddkg.erl
@@ -511,10 +511,12 @@ store_leader_change(DKG, Sender, {signed_leader_change, ProposedLeader, _Proof}=
             false
     end.
 
-verify_proofs({vss_ready_proofs, Proofs}, DKG) ->
+verify_proofs({vss_ready_proofs, Proofs}, DKG = #dkg{n=N, t=T, f=F}) ->
     Res = lists:all(fun({VSSId, Proof}) ->
                             %% get the VSS state for this ID
                             VSS = maps:get(VSSId, DKG#dkg.shares_map),
+                            %% check we have enough proofs
+                            maps:size(Proof) == (N - T - F) andalso
                             %% check that every ready proof is valid for this VSS
                             lists:all(fun({Sender, ReadyProof}) ->
                                                         dkg_hybridvss:verify_proof(VSS, Sender, ReadyProof)

--- a/src/dkg_hybridvss.erl
+++ b/src/dkg_hybridvss.erl
@@ -1,11 +1,12 @@
 -module(dkg_hybridvss).
 
--export([init/8]).
+-export([init/10]).
 
 -export([input/2,
          serialize/1,
-         deserialize/2,
-         status/1
+         deserialize/4,
+         status/1,
+         verify_proof/3
         ]).
 
 -export([handle_msg/3]).
@@ -21,7 +22,9 @@
           session :: session(),
           received_commitment = false :: boolean(),
           commitments = #{} :: #{binary() => dkg_commitment:commitment()},
-          callback = false :: boolean()
+          callback = false :: boolean(),
+          signfun :: signfun(),
+          verifyfun :: verifyfun()
          }).
 
 -record(serialized_vss, {
@@ -38,18 +41,26 @@
           callback :: boolean()
          }).
 
--type session() :: {Dealer :: pos_integer(), Round :: pos_integer()}.
+%% Note that the 'Round' here is assumed to be some unique combination of members and some strictly increasing counter(s) or nonce.
+%% For example, something like the SHA of the public keys of all the members and some global DKG counter.
+%% The counter/nonce should NOT repeat under any circumstances or ready messages may be reused to forge subsequent round results.
+-type session() :: {Dealer :: pos_integer(), Round :: binary()}.
 -type send_msg() :: {unicast, pos_integer(), {send, {session(), dkg_commitmentmatrix:serialized_matrix(), dkg_polynomial:polynomial()}}}.
 -type echo_msg() :: {unicast, pos_integer(), {echo, {session(), dkg_commitmentmatrix:serialized_matrix(), binary()}}}.
 -type ready_msg() :: {unicast, pos_integer(), {ready, {session(), dkg_commitmentmatrix:serialized_matrix(), binary()}}}.
 -type result() :: {result, {session(), dkg_commitment:commitment(), [erlang_pbc:element()]}}.
 -type vss() :: #vss{}.
 -type serialized_vss() :: #serialized_vss{}.
+-type signfun() :: fun((Msg :: binary()) -> Signature :: binary()).
+-type verifyfun() :: fun((Sender :: pos_integer(), Msg :: binary(), Signature :: binary()) -> boolean()).
 
 -export_type([vss/0, session/0, serialized_vss/0]).
 
--spec init(Id :: pos_integer(), N :: pos_integer(), F :: pos_integer(), T :: pos_integer(), erlang_pbc:element(), erlang_pbc:element(), session(), boolean())-> vss().
-init(Id, N, F, T, G1, G2, Session, Callback) ->
+-spec init(Id :: pos_integer(), N :: pos_integer(), F :: pos_integer(), T :: pos_integer(),
+           G1 :: erlang_pbc:element(), G2 :: erlang_pbc:element(),
+           Session :: session(), Callback :: boolean(),
+           SignFun :: signfun(), VerifyFun :: verifyfun())-> vss().
+init(Id, N, F, T, G1, G2, Session, Callback, SignFun, VerifyFun) ->
     true = N >= (3*T + 2*F + 1),
     #vss{id=Id,
          n=N,
@@ -58,7 +69,9 @@ init(Id, N, F, T, G1, G2, Session, Callback) ->
          session=Session,
          u=G1,
          u2=G2,
-         callback=Callback}.
+         callback=Callback,
+         signfun = SignFun,
+         verifyfun = VerifyFun}.
 
 %% upon a message (Pd, τ, in, share, s): /* only Pd */
 %%     choose a symmetric bivariate polynomial φ(x,y) = ∑tj,l=0 φjl x^j y^l ∈R Zp[x,y] and φ00 = s
@@ -132,7 +145,7 @@ handle_msg(VSS, _Sender, {send, {_Session, _Commitment, _A}}) ->
 %%             Lagrange-interpolate a from AC
 %%             for all j ∈ [1, n] do
 %%                  send the message (Pd, τ, ready, C, a(j)) to Pj
-handle_msg(VSS=#vss{id=Id, n=N, t=T, session=Session, done=false, callback=true}, Sender, {echo, {Session, SerializedCommitmentMatrix0, SA}}) ->
+handle_msg(VSS=#vss{id=Id, n=N, t=T, session=Session, done=false, callback=CB}, Sender, {echo, {Session, SerializedCommitmentMatrix0, SA}}) ->
     Commitment = get_commitment(SerializedCommitmentMatrix0, VSS),
     A = erlang_pbc:binary_to_element(VSS#vss.u, SA),
     case dkg_commitment:verify_point(Commitment, Sender, Id, A) of
@@ -141,34 +154,19 @@ handle_msg(VSS=#vss{id=Id, n=N, t=T, session=Session, done=false, callback=true}
                 {true, NewCommitment} ->
                     case dkg_commitment:num_echoes(NewCommitment) == ceil((N+T+1)/2) andalso
                          dkg_commitment:num_readies(NewCommitment) < (T+1) of
-                        true ->
+                        true when CB == true ->
                             Subshares = dkg_commitment:interpolate(NewCommitment, echo, dkg_util:allnodes(N)),
+                            ReadyProof = construct_proof(VSS),
                             Msgs = lists:map(fun(Node) ->
                                                      erlang_pbc:element_to_binary(lists:nth(Node+1, Subshares))
                                              end, dkg_util:allnodes(N)),
-                            {store_commitment(NewCommitment, VSS), {send, [{callback, {ready, {Session, SerializedCommitmentMatrix0, Msgs}}}]}};
-                        false ->
-                            {store_commitment(NewCommitment, VSS), ok}
-                    end;
-                {false, OldCommitment} ->
-                    {store_commitment(OldCommitment, VSS), ok}
-            end;
-        false ->
-            {VSS, ok}
-    end;
-handle_msg(VSS=#vss{id=Id, n=N, t=T, session=Session, done=false}, Sender, {echo, {Session, SerializedCommitmentMatrix0, SA}}) ->
-    Commitment = get_commitment(SerializedCommitmentMatrix0, VSS),
-    A = erlang_pbc:binary_to_element(VSS#vss.u, SA),
-    case dkg_commitment:verify_point(Commitment, Sender, Id, A) of
-        true ->
-            case dkg_commitment:add_echo(Commitment, Sender, A) of
-                {true, NewCommitment} ->
-                    case dkg_commitment:num_echoes(NewCommitment) == ceil((N+T+1)/2) andalso
-                         dkg_commitment:num_readies(NewCommitment) < (T+1) of
+                            {store_commitment(NewCommitment, VSS), {send, [{callback, {ready, {Session, SerializedCommitmentMatrix0, Msgs, ReadyProof}}}]}};
                         true ->
+                            %% not in callback mode
                             Subshares = dkg_commitment:interpolate(NewCommitment, echo, dkg_util:allnodes(N)),
+                            ReadyProof = construct_proof(VSS),
                             Msgs = lists:map(fun(Node) ->
-                                                     {unicast, Node, {ready, {Session, SerializedCommitmentMatrix0, erlang_pbc:element_to_binary(lists:nth(Node+1, Subshares))}}}
+                                                     {unicast, Node, {ready, {Session, SerializedCommitmentMatrix0, erlang_pbc:element_to_binary(lists:nth(Node+1, Subshares)), ReadyProof}}}
                                              end, dkg_util:allnodes(N)),
                             {store_commitment(NewCommitment, VSS), {send, Msgs}};
                         false ->
@@ -179,7 +177,7 @@ handle_msg(VSS=#vss{id=Id, n=N, t=T, session=Session, done=false}, Sender, {echo
             end;
         false ->
             {VSS, ok}
-end;
+    end;
 
 %% upon a message (Pd, τ, ready, C, α) from Pm (first time):
 %%     if verify-point(C, i, m, α) then
@@ -190,54 +188,31 @@ end;
 %%                 send the message (Pd, τ, ready, C, a(j)) to Pj
 %%     else if rC = n − t − f then
 %%         si ← a(0); output (Pd , τ, out, shared, C, si )
-handle_msg(VSS=#vss{n=N, t=T, f=F, id=Id, done=false, callback=true}, Sender, {ready, {Session, SerializedCommitmentMatrix0, SA}}=_ReadyMsg) ->
+handle_msg(VSS=#vss{n=N, t=T, f=F, id=Id, done=false, callback=CB}, Sender, {ready, {Session, SerializedCommitmentMatrix0, SA, ReadyProof}}=_ReadyMsg) ->
     Commitment = get_commitment(SerializedCommitmentMatrix0, VSS),
     A = erlang_pbc:binary_to_element(VSS#vss.u, SA),
-    case dkg_commitment:verify_point(Commitment, Sender, Id, A) of
+    case verify_proof(VSS, Sender, ReadyProof) andalso
+         dkg_commitment:verify_point(Commitment, Sender, Id, A) of
         true ->
-            %% TODO the ready should be signed, so we should store the signature in the commitment as well
+            %% The point is valid and we have a ready proof
             case dkg_commitment:add_ready(Commitment, Sender, A) of
                 {true, NewCommitment} ->
                     case dkg_commitment:num_readies(NewCommitment) == (T+1) andalso
                          dkg_commitment:num_echoes(NewCommitment) < ceil((N+T+1)/2) of
-                        true ->
+                        true when CB == true ->
                             SubShares = dkg_commitment:interpolate(NewCommitment, ready, dkg_util:allnodes(N)),
+                            ReadyProof = construct_proof(VSS),
                             Msgs = lists:map(fun(Node) ->
                                                      erlang_pbc:element_to_binary(lists:nth(Node+1, SubShares))
                                              end, dkg_util:allnodes(N)),
                             NewVSS = store_commitment(NewCommitment, VSS),
-                            {NewVSS, {send, [{callback, {ready, {Session, SerializedCommitmentMatrix0, Msgs}}}]}};
-                        false ->
-                            case dkg_commitment:num_readies(NewCommitment) == (N-T-F) of
-                                true->
-                                    [SubShare] = dkg_commitment:interpolate(NewCommitment, ready, []),
-                                    %% clear the commitments out of our state and return the winning one
-                                    {VSS#vss{done=true, commitments=#{}}, {result, {Session, NewCommitment, SubShare}}};
-                                false ->
-                                    NewVSS = store_commitment(NewCommitment, VSS),
-                                    {NewVSS, ok}
-                            end
-                    end;
-                {false, OldCommitment} ->
-                    {store_commitment(OldCommitment, VSS), ok}
-            end;
-        false ->
-            {VSS, ok}
-    end;
-handle_msg(VSS=#vss{n=N, t=T, f=F, id=Id, done=false}, Sender, {ready, {Session, SerializedCommitmentMatrix0, SA}}=_ReadyMsg) ->
-    Commitment = get_commitment(SerializedCommitmentMatrix0, VSS),
-    A = erlang_pbc:binary_to_element(VSS#vss.u, SA),
-    case dkg_commitment:verify_point(Commitment, Sender, Id, A) of
-        true ->
-            %% TODO the ready should be signed, so we should store the signature in the commitment as well
-            case dkg_commitment:add_ready(Commitment, Sender, A) of
-                {true, NewCommitment} ->
-                    case dkg_commitment:num_readies(NewCommitment) == (T+1) andalso
-                         dkg_commitment:num_echoes(NewCommitment) < ceil((N+T+1)/2) of
+                            {NewVSS, {send, [{callback, {ready, {Session, SerializedCommitmentMatrix0, Msgs, ReadyProof}}}]}};
                         true ->
+                            %% not in callback mode
                             SubShares = dkg_commitment:interpolate(NewCommitment, ready, dkg_util:allnodes(N)),
+                            ReadyProof = construct_proof(VSS),
                             Msgs = lists:map(fun(Node) ->
-                                                     {unicast, Node, {ready, {Session, SerializedCommitmentMatrix0, erlang_pbc:element_to_binary(lists:nth(Node+1, SubShares))}}}
+                                                     {unicast, Node, {ready, {Session, SerializedCommitmentMatrix0, erlang_pbc:element_to_binary(lists:nth(Node+1, SubShares)), ReadyProof}}}
                                              end, dkg_util:allnodes(N)),
                             NewVSS = store_commitment(NewCommitment, VSS),
                             {NewVSS, {send, Msgs}};
@@ -286,7 +261,7 @@ serialize(#vss{id=Id,
                     commitments=maps:map(fun(_, V) -> dkg_commitment:serialize(V) end, Commitments),
                     callback=Callback}.
 
--spec deserialize(serialized_vss(), erlang_pbc:element()) -> vss().
+-spec deserialize(serialized_vss(), erlang_pbc:element(), fun(), fun()) -> vss().
 deserialize(#serialized_vss{id=Id,
                             n=N,
                             f=F,
@@ -297,7 +272,7 @@ deserialize(#serialized_vss{id=Id,
                             session=Session,
                             received_commitment=ReceivedCommitment,
                             commitments=SerializedCommitments,
-                            callback=Callback}, Element) ->
+                            callback=Callback}, Element, SignFun, VerifyFun) ->
     #vss{id=Id,
          n=N,
          f=F,
@@ -308,6 +283,8 @@ deserialize(#serialized_vss{id=Id,
          session=Session,
          received_commitment=ReceivedCommitment,
          commitments=maps:map(fun(_, V) -> dkg_commitment:deserialize(V, Element) end, SerializedCommitments),
+         signfun=SignFun,
+         verifyfun=VerifyFun,
          callback=Callback}.
 
 -spec status(vss()) -> map().
@@ -320,7 +297,7 @@ status(VSS) ->
                                        num_echoes => dkg_commitment:num_echoes(C),
                                        num_readies => dkg_commitment:num_readies(C),
                                        echoes => maps:keys(dkg_commitment:echoes(C)),
-                                       readies => maps:keys(dkg_commitment:readies(C))
+                                       readies => maps:keys(dkg_commitment:ready_proofs(C))
                                       }
                               end, VSS#vss.commitments),
       done => VSS#vss.done
@@ -339,3 +316,16 @@ get_commitment(SerializedMatrix, VSS = #vss{n=N, t=T, u2=G2}) ->
 store_commitment(Commitment, VSS) ->
     Key = erlang:phash2(dkg_commitment:binary_matrix(Commitment)),
     VSS#vss{commitments=maps:put(Key, Commitment, VSS#vss.commitments)}.
+
+construct_proof(#vss{id=Id, session={Dealer, Round}, signfun=SignFun}) ->
+    %% Construct and sign a proof
+    %% XXX See the notes on the construction of 'Round' above
+    %% This proof is the evidence used to attest that we had enough shares to interpolate the secret
+    SignFun(<<Id:32/integer-unsigned-little,
+              Dealer:32/integer-unsigned-little, Round/binary>>).
+
+
+verify_proof(#vss{session={Dealer, Round}, verifyfun=VerifyFun}, Sender, Proof) ->
+    Msg = <<Sender:32/integer-unsigned-little,
+              Dealer:32/integer-unsigned-little, Round/binary>>,
+    VerifyFun(Sender, Msg, Proof).

--- a/test/dkg_distributed_SUITE.erl
+++ b/test/dkg_distributed_SUITE.erl
@@ -83,7 +83,7 @@ run(N, F, T, Curve, G1, G2, Nodes) ->
     Workers = [{Node, rpc:call(Node,
                                dkg_worker,
                                start_link,
-                               [I, N, F, T, Curve, erlang_pbc:element_to_binary(G1), erlang_pbc:element_to_binary(G2), 0])} || {I, Node} <- dkg_test_utils:enumerate(Nodes)],
+                               [I, N, F, T, Curve, erlang_pbc:element_to_binary(G1), erlang_pbc:element_to_binary(G2), <<0>>])} || {I, Node} <- dkg_test_utils:enumerate(Nodes)],
     ok = global:sync(),
 
     ct:pal("workers ~p", [Workers]),

--- a/test/dkg_handler.erl
+++ b/test/dkg_handler.erl
@@ -40,7 +40,7 @@ init(DKGArgs) ->
                    false ->
                        {G1, G2}
                end,
-    DKG = dkg_hybriddkg:init(ID, N, F, T, G1_Prime, G2_Prime, Round, [{callback, true}]),
+    DKG = dkg_hybriddkg:init(ID, N, F, T, G1_Prime, G2_Prime, Round, [{callback, true}, {signfun, fun(_) -> <<"lol">> end}, {verifyfun, fun(_, _, _) -> true end}]),
     {ok, #state{round=Round, id=ID, n=N, t=T, dkg=DKG, curve=Curve, g1=G1_Prime, g2=G2_Prime}}.
 
 handle_command(start_round, State) ->

--- a/test/dkg_handler.erl
+++ b/test/dkg_handler.erl
@@ -88,8 +88,8 @@ callback_message(Actor, Message, _State) ->
             term_to_binary({Id, {send, {Session, SerializedCommitment, lists:nth(Actor, Shares)}}});
         {Id, {echo, {Session, SerializedCommitment, Shares}}} ->
             term_to_binary({Id, {echo, {Session, SerializedCommitment, lists:nth(Actor, Shares)}}});
-        {Id, {ready, {Session, SerializedCommitment, Shares}}} ->
-            term_to_binary({Id, {ready, {Session, SerializedCommitment, lists:nth(Actor, Shares)}}})
+        {Id, {ready, {Session, SerializedCommitment, Shares, Proof}}} ->
+            term_to_binary({Id, {ready, {Session, SerializedCommitment, lists:nth(Actor, Shares), Proof}}})
     end.
 
 
@@ -110,7 +110,7 @@ deserialize(Binary) ->
     Group = erlang_pbc:group_new(State#state.curve),
     G1 = erlang_pbc:binary_to_element(Group, State#state.g1),
     G2 = erlang_pbc:binary_to_element(Group, State#state.g2),
-    DKG = dkg_hybriddkg:deserialize(State#state.dkg, G1),
+    DKG = dkg_hybriddkg:deserialize(State#state.dkg, G1, fun(_) -> <<"lol">> end, fun(_, _, _) -> true end),
     PrivKey = case State#state.privkey of
         undefined ->
             undefined;

--- a/test/dkg_hybriddkg_SUITE.erl
+++ b/test/dkg_hybriddkg_SUITE.erl
@@ -83,7 +83,7 @@ split_key_test(Config) ->
     T = proplists:get_value(t, Config),
     {G1, G2} = dkg_test_utils:generate('SS512'),
 
-    BaseConfig = [N, F, T, G1, G2, {1, 0}, [{elections, true}]],
+    BaseConfig = [N, F, T, G1, G2, <<0>>, [{elections, true}]],
 
     Init =
         fun() ->
@@ -145,7 +145,7 @@ run(N, F, T, Module, Curve, G1, G2, InitialLeader) ->
 
 run(N, F, T, Module, Curve, G1, G2, InitialLeader, Options) ->
     {StatesWithId, Replies} = lists:unzip(lists:map(fun(E) ->
-                                                   {State, {send, Replies}} = Module:start(Module:init(E, N, F, T, G1, G2, {1, 0}, Options)),
+                                                   {State, {send, Replies}} = Module:start(Module:init(E, N, F, T, G1, G2, <<0>>, Options)),
                                                    {{E, State}, {E, {send, Replies}}}
                                            end, lists:seq(InitialLeader, N))),
 

--- a/test/dkg_hybriddkg_SUITE.erl
+++ b/test/dkg_hybriddkg_SUITE.erl
@@ -3,6 +3,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("relcast/include/fakecast.hrl").
+-include_lib("public_key/include/public_key.hrl").
 
 -export([all/0, init_per_testcase/2, end_per_testcase/2]).
 -export([
@@ -10,7 +11,9 @@
          asymmetric_test/1,
          leader_change_symmetric_test/1,
          leader_change_asymmetric_test/1,
-         split_key_test/1
+         split_key_test/1,
+         sign_verify_test/1,
+         sign_verify_fail_test/1
         ]).
 
 all() ->
@@ -19,7 +22,9 @@ all() ->
      asymmetric_test,
      leader_change_symmetric_test,
      leader_change_asymmetric_test,
-     split_key_test
+     split_key_test,
+     sign_verify_test,
+     sign_verify_fail_test
     ].
 
 init_per_testcase(_, Config) ->
@@ -59,7 +64,7 @@ leader_change_symmetric_test(Config) ->
     InitialLeader = 2,
     Module = proplists:get_value(module, Config),
     {G1, G2} = dkg_test_utils:generate('SS512'),
-    run(N, F, T, Module, 'SS512', G1, G2, InitialLeader, [{elections, true}]).
+    run(N, F, T, Module, 'SS512', G1, G2, InitialLeader, [{elections, true}, {signfun, fun(_) -> <<"lol">> end}, {verifyfun, fun(_, _, _) -> true end}]).
 
 leader_change_asymmetric_test(Config) ->
     N = proplists:get_value(n, Config),
@@ -68,7 +73,49 @@ leader_change_asymmetric_test(Config) ->
     InitialLeader = 2,
     Module = proplists:get_value(module, Config),
     {G1, G2} = dkg_test_utils:generate('MNT224'),
-    run(N, F, T, Module, 'MNT224', G1, G2, InitialLeader, [{elections, true}]).
+    run(N, F, T, Module, 'MNT224', G1, G2, InitialLeader, [{elections, true}, {signfun, fun(_) -> <<"lol">> end}, {verifyfun, fun(_, _, _) -> true end}]).
+
+sign_verify_test(Config) ->
+    N = proplists:get_value(n, Config),
+    F = proplists:get_value(f, Config),
+    T = proplists:get_value(t, Config),
+    Keys = [ begin
+                 PrivKey = public_key:generate_key({namedCurve,?secp256r1}),
+                 #'ECPrivateKey'{parameters=_Params, publicKey=PubKey} = PrivKey,
+                 {PrivKey, {#'ECPoint'{point = PubKey}, {namedCurve, ?secp256r1}}}
+             end || _ <- lists:seq(1, N)],
+
+    VerifyFun = fun(Id, Msg, Signature) ->
+                        {_, PubKey} = lists:nth(Id, Keys),
+                        public_key:verify(Msg, sha256, Signature, PubKey)
+                end,
+    SigFuns = [ fun(Msg) -> public_key:sign(Msg, sha256, PrivKey) end || {PrivKey, _} <- Keys ],
+    InitialLeader = 2,
+    Module = proplists:get_value(module, Config),
+    {G1, G2} = dkg_test_utils:generate('SS512'),
+    run(N, F, T, Module, 'SS512', G1, G2, InitialLeader, [{elections, true}, {signfuns, SigFuns}, {verifyfun, VerifyFun}]).
+
+sign_verify_fail_test(Config) ->
+    N = proplists:get_value(n, Config),
+    F = proplists:get_value(f, Config),
+    T = proplists:get_value(t, Config),
+    Keys = [ begin
+                 PrivKey = public_key:generate_key({namedCurve,?secp256r1}),
+                 #'ECPrivateKey'{parameters=_Params, publicKey=PubKey} = PrivKey,
+                 {PrivKey, {#'ECPoint'{point = PubKey}, {namedCurve, ?secp256r1}}}
+             end || _ <- lists:seq(1, N)],
+
+    VerifyFun = fun(Id, Msg, Signature) ->
+                        %% XXX reverse the key order, so nothing can be verified
+                        {_, PubKey} = lists:nth(Id, lists:reverse(Keys)),
+                        public_key:verify(Msg, sha256, Signature, PubKey)
+                end,
+    SigFuns = [ fun(Msg) -> public_key:sign(Msg, sha256, PrivKey) end || {PrivKey, _} <- Keys ],
+    InitialLeader = 2,
+    Module = proplists:get_value(module, Config),
+    {G1, G2} = dkg_test_utils:generate('SS512'),
+    ?assertException(error, {assertEqual, _}, run(N, F, T, Module, 'SS512', G1, G2, InitialLeader, [{elections, true}, {signfuns, SigFuns}, {verifyfun, VerifyFun}])).
+
 
 -record(sk_state,
         {
@@ -83,7 +130,7 @@ split_key_test(Config) ->
     T = proplists:get_value(t, Config),
     {G1, G2} = dkg_test_utils:generate('SS512'),
 
-    BaseConfig = [N, F, T, G1, G2, <<0>>, [{elections, true}]],
+    BaseConfig = [N, F, T, G1, G2, <<0>>, [{elections, true}, {signfun, fun(_) -> <<"lol">> end}, {verifyfun, fun(_, _, _) -> true end}]],
 
     Init =
         fun() ->
@@ -141,11 +188,20 @@ sk_model(_Message, _From, _To, _NodeState, _NewState, _Actions, ModelState) ->
 
 
 run(N, F, T, Module, Curve, G1, G2, InitialLeader) ->
-    run(N, F, T, Module, Curve, G1, G2, InitialLeader, []).
+    run(N, F, T, Module, Curve, G1, G2, InitialLeader, [{signfun, fun(_) -> <<"lol">> end}, {verifyfun, fun(_, _, _) -> true end}]).
 
 run(N, F, T, Module, Curve, G1, G2, InitialLeader, Options) ->
     {StatesWithId, Replies} = lists:unzip(lists:map(fun(E) ->
-                                                   {State, {send, Replies}} = Module:start(Module:init(E, N, F, T, G1, G2, <<0>>, Options)),
+                                                            %% check if we have a real, per node, sig fun
+                                                            SigFun = case proplists:get_value(signfuns, Options) of
+                                                                         undefined ->
+                                                                             {signfun, S} = lists:keyfind(signfun, 1, Options),
+                                                                             S;
+                                                                         SigFuns when is_list(SigFuns) ->
+                                                                             lists:nth(E, SigFuns)
+                                                                     end,
+                                                   {State, {send, Replies}} = Module:start(Module:init(E, N, F, T, G1, G2, <<0>>,
+                                                                                                       lists:keystore(signfun, 1, Options, {signfun, SigFun}))),
                                                    {{E, State}, {E, {send, Replies}}}
                                            end, lists:seq(InitialLeader, N))),
 

--- a/test/dkg_hybridvss_SUITE.erl
+++ b/test/dkg_hybridvss_SUITE.erl
@@ -62,7 +62,7 @@ fake_symmetric(Config) ->
     Curve = 'SS512',
     {G1, G2} = dkg_test_utils:generate(Curve),
 
-    TestArgs = [N, F, T, G1, G2, {1, 0}, false],
+    TestArgs = [N, F, T, G1, G2, {1, <<0>>}, false, fun(_) -> <<"lol">> end, fun(_, _, _) -> true end],
     Init = fun() ->
                    {ok,
                     #fc_conf{
@@ -103,7 +103,7 @@ fake_asymmetric(Config) ->
     T = proplists:get_value(t, Config),
     Curve = 'MNT224',
     {G1, G2} = dkg_test_utils:generate(Curve),
-    TestArgs = [N, F, T, G1, G2, {1, 0}, false],
+    TestArgs = [N, F, T, G1, G2, {1, <<0>>}, false, fun(_) -> <<"lol">> end, fun(_, _, _) -> true end],
     Init = fun() ->
                    {ok,
                     #fc_conf{
@@ -124,7 +124,7 @@ fake_asymmetric(Config) ->
 
 run(Module, N, F, T, Curve, G1, G2) ->
 
-    [Dealer | Rest] = [ Module:init(Id, N, F, T, G1, G2, {1, 0}, false) || Id <- lists:seq(1, N) ],
+    [Dealer | Rest] = [ Module:init(Id, N, F, T, G1, G2, {1, <<0>>}, false, fun(_) -> <<"lol">> end, fun(_, _, _) -> true end) || Id <- lists:seq(1, N) ],
 
     Secret = erlang_pbc:element_random(erlang_pbc:element_new('Zr', G1)),
 

--- a/test/dkg_multiproc_SUITE.erl
+++ b/test/dkg_multiproc_SUITE.erl
@@ -40,7 +40,7 @@ asymmetric_test(Config) ->
     run(N, F, T, 'MNT224', G1, G2).
 
 run(N, F, T, Curve, G1, G2) ->
-    Workers = [ element(2, dkg_worker:start_link(Id, N, F, T, Curve, G1, G2, 0)) || Id <- lists:seq(1, N) ],
+    Workers = [ element(2, dkg_worker:start_link(Id, N, F, T, Curve, G1, G2, <<0>>)) || Id <- lists:seq(1, N) ],
 
     [ dkg_worker:start_round(Worker) || Worker <- Workers ],
     %% wait for DKG to complete

--- a/test/dkg_relcast_distributed_SUITE.erl
+++ b/test/dkg_relcast_distributed_SUITE.erl
@@ -94,7 +94,7 @@ run(N, F, T, Curve, G1, G2, Nodes, DataDir) ->
                                  {g1, erlang_pbc:element_to_binary(G1)},
                                  {g2, erlang_pbc:element_to_binary(G2)},
                                  {data_dir, DataDir},
-                                 {round, 0}]])} || {I, Node} <- dkg_test_utils:enumerate(Nodes)],
+                                 {round, <<0>>}]])} || {I, Node} <- dkg_test_utils:enumerate(Nodes)],
     ok = global:sync(),
 
     ct:pal("workers ~p", [Workers]),

--- a/test/dkg_relcast_multiproc_SUITE.erl
+++ b/test/dkg_relcast_multiproc_SUITE.erl
@@ -20,7 +20,7 @@ init_per_testcase(TestCase, Config) ->
     T = ((N - 1) div 3) - 1,
     F = 1,
     Module = dkg_hybriddkg,
-    Round = 0,
+    Round = <<0>>,
     DataDir = atom_to_list(?MODULE) ++ atom_to_list(TestCase) ++ "data",
     [{n, N}, {f, F}, {t, T}, {round, Round}, {module, Module}, {data_dir, DataDir} | Config].
 

--- a/test/dkg_worker.erl
+++ b/test/dkg_worker.erl
@@ -15,7 +15,7 @@
           curve :: 'SS512' | 'MNT224',
           g1 :: erlang_pbc:element(),
           g2 :: erlang_pbc:element(),
-          round :: non_neg_integer(),
+          round :: binary(),
           privkey :: undefined | tpke_privkey:privkey()
          }).
 
@@ -103,7 +103,7 @@ do_send([{multicast, Msg}|T], State) ->
 
 %% helper functions
 update_dkg(DKG, State)->
-    NewDKG = dkg_hybriddkg:deserialize(dkg_hybriddkg:serialize(DKG), State#state.g1),
+    NewDKG = dkg_hybriddkg:deserialize(dkg_hybriddkg:serialize(DKG), State#state.g1, fun(_) -> <<"lol">> end, fun(_, _, _) -> true end),
     State#state{dkg=NewDKG}.
 
 name(N) ->

--- a/test/dkg_worker.erl
+++ b/test/dkg_worker.erl
@@ -45,7 +45,7 @@ init([Id, N, F, T, Curve, G10, G20, Round]) ->
                    false ->
                        {G10, G20}
                end,
-    DKG = dkg_hybriddkg:init(Id, N, F, T, G1, G2, Round, []),
+    DKG = dkg_hybriddkg:init(Id, N, F, T, G1, G2, Round, [{signfun, fun(_) -> <<"lol">> end}, {verifyfun, fun(_, _, _) -> true end}]),
     {ok, #state{n=N, f=F, t=T, id=Id, curve=Curve, g1=G1, g2=G2, round=Round, dkg=DKG}}.
 
 handle_call(is_done, _From, State) ->


### PR DESCRIPTION
The DKG election requires signed proof enough distinct readies were
obtained from a VSS for it to be able to complete. These signed readies
are distributed from the leader to the follower nodes so that the
leader's claim of which VSSes it wants to use for the final key can be
verified.

I need to add some tests with actual keys and stuff before this can merge...