### PR TITLE
update relcast API

### DIFF
--- a/test/dkg_relcast_worker.erl
+++ b/test/dkg_relcast_worker.erl
@@ -39,7 +39,8 @@ init(Args) ->
     ID = proplists:get_value(id, Args),
     DataDir = proplists:get_value(data_dir, Args),
     Members = lists:seq(1, N),
-    {ok, Relcast} = relcast:start(ID, Members, dkg_handler, Args, [{data_dir, DataDir ++ integer_to_list(ID)}]),
+    {ok, Relcast} = relcast:start(ID, Members, dkg_handler, Args, [{data_dir, DataDir ++ integer_to_list(ID)},
+                                                                   {create, true}]),
     Peers = maps:from_list([{I, undefined} || I <- Members, I /= ID ]),
     {ok, do_send(#state{relcast=Relcast, id=ID, peers=Peers})}.
 


### PR DESCRIPTION
relcast open now requires a create parameter that defaults to false.  this repo isn't locked to a particular version of relcast, so got broken by pulling the latest, causing spurious test failures.  this PR fixes API usage, and should make the test pass.